### PR TITLE
Update default value for the size of the rendering

### DIFF
--- a/Init.aplf
+++ b/Init.aplf
@@ -1,7 +1,7 @@
  BMPR←{size}Init bmp;⎕IO;⎕ML;scale;canins;canvas;atts;fills;style;w;h;img;html;add
 ⍝ Return a new HTMLRenderer containing bmp, with optional size
 
- :If 0=⎕NC'size' ⋄ size←600 600 ⋄ :EndIf ⍝ Not sure exactly what units these are
+ :If 0=⎕NC'size' ⋄ size←⍴bmp ⋄ :EndIf ⍝ Not sure exactly what units these are
  html←size ImageHtml bmp
 
  scale←1.3 ⍝ Need to create an HTMLRenderer this much bigger than Size


### PR DESCRIPTION
Even though it may not be clear what units the `size` is in, a fixed default value means that we must provide the left argument to `Init`, or else the default will not respect the aspect ratio of non-square `bmp` given. Using `⍴bmp` as the default value means that the aspect ratio of the `bmp` is respected and preserved.